### PR TITLE
SCOPE param to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Step 6: Set up all the correct options (see below for available options)
  * OAUTHADMIN_PING_INTERVAL (optional, defaults to 300): Minimum number of seconds between ping requests
  * OAUTHADMIN_PING: (optional, defaults to None) This optional function takes an oauth token and returns True if it's still valid and False if it's no longer valid (if they have logged out of the oauth server)
  * OAUTHADMIN_DEFAULT_NEXT_URL: (optional, defaults to /admin). This optional value is the default page that a successful oauth login process will land you on.
+* OAUTHADMIN_SCOPE: (optional, defaults to ["default"]). It is possible to configure and pass optional scope params.
 
 ## Testing
 

--- a/oauthadmin/settings.py
+++ b/oauthadmin/settings.py
@@ -4,7 +4,7 @@ defaults = {
     # default values for all django-oauth2-admin settings
     "GET_USER": 'oauthadmin.stubs.get_user',
     "PING_INTERVAL": 300,
-    "OAUTHADMIN_DEFAULT_NEXT_URL": "/admin/",
+    "DEFAULT_NEXT_URL": "/admin/",
     "SCOPE": ["default"],
 }
 

--- a/oauthadmin/settings.py
+++ b/oauthadmin/settings.py
@@ -6,6 +6,7 @@ defaults = {
     "PING_INTERVAL": 300,
     "DEFAULT_NEXT_URL": "/admin/",
     "SCOPE": ["default"],
+    "DEFAULT_NOT_LOGGED_URL": "/admin/",
 }
 
 global_prefix = 'OAUTHADMIN_'

--- a/oauthadmin/settings.py
+++ b/oauthadmin/settings.py
@@ -5,6 +5,7 @@ defaults = {
     "GET_USER": 'oauthadmin.stubs.get_user',
     "PING_INTERVAL": 300,
     "OAUTHADMIN_DEFAULT_NEXT_URL": "/admin/",
+    "SCOPE": ["default"],
 }
 
 global_prefix = 'OAUTHADMIN_'

--- a/oauthadmin/views.py
+++ b/oauthadmin/views.py
@@ -49,7 +49,7 @@ def login(request):
     oauth = OAuth2Session(
         client_id=app_setting('CLIENT_ID'),
         redirect_uri=redirect_uri,
-        scope=["default"],
+        scope=app_setting('SCOPE'),
         state=state,
     )
     authorization_url, state = oauth.authorization_url(app_setting('AUTH_URL'))

--- a/oauthadmin/views.py
+++ b/oauthadmin/views.py
@@ -79,9 +79,10 @@ def callback(request):
 
     user = import_by_path(app_setting('GET_USER'))(token)
 
-    request.session['last_verified_at'] = int(time())
-    request.session['oauth_token'] = token
-    request.session['user'] = user
+    if user:
+        request.session['last_verified_at'] = int(time())
+        request.session['oauth_token'] = token
+        request.session['user'] = user
 
     next = json.loads(base64.b64decode(request.session['oauth_state']).decode('utf-8'))['next']
     if not next:


### PR DESCRIPTION
Two changes are in this change request:

1. SCOPE param is configurable (currently it hardcodes value "default" and it fails on some providers like Google)
2. Removed prefix "OAUTHADMIN_" from DEFAULT_NEXT_URL as it is global prefix.