### PR TITLE
Scope can be configured in settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Step 6: Set up all the correct options (see below for available options)
  * OAUTHADMIN_PING_INTERVAL (optional, defaults to 300): Minimum number of seconds between ping requests
  * OAUTHADMIN_PING: (optional, defaults to None) This optional function takes an oauth token and returns True if it's still valid and False if it's no longer valid (if they have logged out of the oauth server)
  * OAUTHADMIN_DEFAULT_NEXT_URL: (optional, defaults to /admin). This optional value is the default page that a successful oauth login process will land you on.
+ * OAUTHADMIN_SCOPE: (optional, defaults to ['default']). This is a list of authorization scopes.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Step 6: Set up all the correct options (see below for available options)
  * OAUTHADMIN_CLIENT_ID: Your oAuth client ID
  * OAUTHADMIN_CLIENT_SECRET: oAuth client secret
  * OAUTHADMIN_BASE_URL: The landing point for all oAuth related queries.
- * OATHADMIN_AUTH_URL: oAuth provider URL
+ * OAUTHADMIN_AUTH_URL: oAuth provider URL
  * OAUTHADMIN_TOKEN_URL: oAuth bearer token provider URL
  * OAUTHADMIN_PING_INTERVAL (optional, defaults to 300): Minimum number of seconds between ping requests
  * OAUTHADMIN_PING: (optional, defaults to None) This optional function takes an oauth token and returns True if it's still valid and False if it's no longer valid (if they have logged out of the oauth server)

--- a/oauthadmin/settings.py
+++ b/oauthadmin/settings.py
@@ -5,6 +5,7 @@ defaults = {
     "GET_USER": 'oauthadmin.stubs.get_user',
     "PING_INTERVAL": 300,
     "OAUTHADMIN_DEFAULT_NEXT_URL": "/admin/",
+    "SCOPE": ['default'],
 }
 
 global_prefix = 'OAUTHADMIN_'

--- a/oauthadmin/views.py
+++ b/oauthadmin/views.py
@@ -54,7 +54,7 @@ def login(request):
     oauth = OAuth2Session(
         client_id=app_setting('CLIENT_ID'),
         redirect_uri=redirect_uri,
-        scope=["default"],
+        scope=app_setting('SCOPE'),
         state=state,
     )
     authorization_url, state = oauth.authorization_url(app_setting('AUTH_URL'))


### PR DESCRIPTION
Hey there!

These changes are useful in case someone wants to make scopes configurable by settings. For example, usually the following scopes are required for Google OAuth and right now it's not possible to make it configurable:
- ``"https://www.googleapis.com/auth/userinfo.email"``
- ``"https://www.googleapis.com/auth/userinfo.profile"``
- ``"https://www.googleapis.com/auth/plus.me"``

Thanks in advance.